### PR TITLE
Add prettier

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "printWidth": 100,
+  "semi": false,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "es5"
+}

--- a/App.tsx
+++ b/App.tsx
@@ -1,5 +1,5 @@
-import { StatusBar } from 'expo-status-bar';
-import { StyleSheet, Text, View } from 'react-native';
+import { StatusBar } from 'expo-status-bar'
+import { StyleSheet, Text, View } from 'react-native'
 
 export default function App() {
   return (
@@ -7,7 +7,7 @@ export default function App() {
       <Text>Open up App.js to start working on your app!</Text>
       <StatusBar style="auto" />
     </View>
-  );
+  )
 }
 
 const styles = StyleSheet.create({
@@ -17,4 +17,4 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
-});
+})

--- a/app.json
+++ b/app.json
@@ -11,9 +11,7 @@
       "resizeMode": "contain",
       "backgroundColor": "#ffffff"
     },
-    "assetBundlePatterns": [
-      "**/*"
-    ],
+    "assetBundlePatterns": ["**/*"],
     "ios": {
       "supportsTablet": true
     },

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,6 @@
-module.exports = function(api) {
-  api.cache(true);
+module.exports = function (api) {
+  api.cache(true)
   return {
     presets: ['babel-preset-expo'],
-  };
-};
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "start": "expo start",
     "android": "expo start --android",
     "ios": "expo start --ios",
-    "web": "expo start --web"
+    "web": "expo start --web",
+    "format:prettier": "prettier --write . --ignore-path .gitignore"
   },
   "dependencies": {
     "@expo/webpack-config": "^18.0.1",
@@ -20,6 +21,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
+    "prettier": "2.8.8",
     "typescript": "^4.9.4"
   },
   "private": true

--- a/yarn.lock
+++ b/yarn.lock
@@ -6976,6 +6976,11 @@ postcss@^8.3.5, postcss@^8.4.19:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
+prettier@2.8.8:
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
+  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
+
 pretty-bytes@5.6.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.6.0.tgz#356256f643804773c82f64723fe78c92c62beaeb"


### PR DESCRIPTION
- Removed the `arrowParens: "avoid"` option because it makes it harder to add type annotations. Reference: https://prettier.io/docs/en/options.html#arrow-function-parentheses.
- Instead of specifying in which type of files we want prettier to run, I believe it makes more sense to let it run in every supported file that is not included in our `.gitignore` by adding the `--ignore-path .gitignore` option to the prettier command.